### PR TITLE
Set default array to OutboxResponse messages in order to fix error ac…

### DIFF
--- a/src/Dto/Messaging/Http/OutboxResponse.php
+++ b/src/Dto/Messaging/Http/OutboxResponse.php
@@ -12,7 +12,7 @@ namespace App\Dto\Messaging\Http {
     class OutboxResponse implements JsonDeserializableInterface
     {
         private string $statusCode;
-        private array $messages;
+        private array $messages = [];
 
         public function jsonDeserialize(array|string $jsonData): JsonDeserializableInterface
         {


### PR DESCRIPTION
When service respond with string `"[]"`, `$outboxService->fetch()` returns `OutboxResponse` with not initialized messages. It causes error when trying to access `$outboxResponse->getMessages()`:
```
Exception 'Error' with message 'Typed property App\Dto\Messaging\Http\OutboxResponse::$messages must not be accessed before initialization'
```

 There is no way to detect empty response to prevent php error. 

Setting default value fix this situation.